### PR TITLE
Backport support for d3d12 (GPU driver of WSLg)

### DIFF
--- a/recipe/851.patch
+++ b/recipe/851.patch
@@ -1,0 +1,15 @@
+diff --git a/ogre2/src/media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl b/ogre2/src/media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
+index 4e3912853..049e3e5b5 100644
+--- a/ogre2/src/media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
++++ b/ogre2/src/media/Hlms/Common/GLSL/CrossPlatformSettings_piece_all.glsl
+@@ -6,6 +6,10 @@
+ 		#version 430 core
+ 	@else
+ 		#version 330 core
++
++		@property( !hlms_readonly_is_tex )
++			#extension GL_ARB_shader_storage_buffer_object: require
++		@end
+ 	@end
+ @end
+ 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,9 +14,11 @@ package:
 source:
   - url: https://github.com/gazebosim/{{ repo_name }}/archive/{{ repo_name }}{{ version }}.tar.gz
     sha256: 93c6ee6fcf31ab344a6d9c93d0a7147a4dedb4ff77c92d0e053bc1d762085581
+    patches:
+      - 851.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: {{ cxx_name }}


### PR DESCRIPTION
Backport fix https://github.com/gazebosim/gz-rendering/pull/851 to support GPU acceleration on WSLg.


Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
