### PR TITLE
Backport support for d3d12 (GPU driver of WSLg) strikes back

### DIFF
--- a/recipe/851.patch
+++ b/recipe/851.patch
@@ -13,3 +13,36 @@ index 4e3912853..049e3e5b5 100644
  	@end
  @end
  
+diff --git a/ogre2/src/media/2.0/scripts/materials/Common/GLSL/GaussianBlurBase_cs.glsl b/ogre2/src/media/2.0/scripts/materials/Common/GLSL/GaussianBlurBase_cs.glsl
+index 9e013df6a..126bf8195 100644
+--- a/ogre2/src/media/2.0/scripts/materials/Common/GLSL/GaussianBlurBase_cs.glsl
++++ b/ogre2/src/media/2.0/scripts/materials/Common/GLSL/GaussianBlurBase_cs.glsl
+@@ -1,5 +1,11 @@
+ @property( syntax != glslvk )
+-	#version 430
++	@property( GL3+ >= 430 )
++		#version 430
++	@else
++		#version 420
++		#extension GL_ARB_arrays_of_arrays: enable
++		#extension GL_ARB_compute_shader: enable
++	@end
+ @else
+ 	#version 450
+ @end
+diff --git a/ogre2/src/media/2.0/scripts/materials/Terra/GLSL/TerraShadowGenerator.glsl b/ogre2/src/media/2.0/scripts/materials/Terra/GLSL/TerraShadowGenerator.glsl
+index e519d2736..94083379a 100644
+--- a/ogre2/src/media/2.0/scripts/materials/Terra/GLSL/TerraShadowGenerator.glsl
++++ b/ogre2/src/media/2.0/scripts/materials/Terra/GLSL/TerraShadowGenerator.glsl
+@@ -1,5 +1,10 @@
+ @property( syntax != glslvk )
+-	#version 430
++	@property( GL3+ >= 430 )
++		#version 430
++	@else
++		#version 420
++		#extension GL_ARB_compute_shader: enable
++	@end
+ 	#define ogre_B0 binding = 0
+ 	#define ogre_B1 binding = 1
+ @else

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -18,7 +18,7 @@ source:
       - 851.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: {{ cxx_name }}


### PR DESCRIPTION
https://github.com/conda-forge/gz-rendering-feedstock/pull/10 only backported the first commit of https://github.com/gazebosim/gz-rendering/pull/851, this PR backports also the second part.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
